### PR TITLE
Update lib/innate/adapter.rb#self.start_webrick

### DIFF
--- a/lib/innate/adapter.rb
+++ b/lib/innate/adapter.rb
@@ -60,7 +60,7 @@ module Innate
     def self.start_webrick(app, config)
       handler = Rack::Handler.get('webrick')
       config = {
-        :BindAddress => config[:Host],
+        :Host => config[:Host],
         :Port => config[:Port],
         :Logger => Log,
       }


### PR DESCRIPTION
In lib/innate/adapter.rb#self.start_webrick, `:BindAddress => config[:Host]` should be `:Host => config[:Host]` because lib/rack/handler/webrick.rb#self.run looks for :Host, not :BindAddress.

What this means is, if you're running Ramaze on a remote server, when Ramaze starts, there's no :Host address (because `:BindAddress` is passed, not `:Host`), so Innate defaults `:Host` to `localhost`. As a result, the server can't be seen outside of the remote server, and your browser will not find the page at `http://www.example.com:7000/`.
