### PR TITLE
Use rack ~> 3.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,6 @@ GEMSPEC = Gem::Specification.new{|s|
   s.platform     = Gem::Platform::RUBY
   s.version      = PROJECT_VERSION
   s.files        = `git ls-files`.split("\n").sort
-  s.has_rdoc     = true
   s.require_path = 'lib'
 }
 

--- a/innate.gemspec
+++ b/innate.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
-# stub: innate 2015.10.28 ruby lib
+# stub: innate 2023.01.05 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "innate"
-  s.version = "2015.10.28"
+  s.version = "2023.01.05"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Michael 'manveru' Fellinger"]
-  s.date = "2015-10-28"
+  s.date = "2023-01-05"
   s.description = "Simple, straight-forward base for web-frameworks."
   s.email = "m.fellinger@gmail.com"
   s.files = [".gems", ".gitignore", ".load_gemset", ".rvmrc", ".travis.yml", "AUTHORS", "CHANGELOG", "COPYING", "MANIFEST", "README.md", "Rakefile", "example/app/retro_games.rb", "example/app/todo/layout/default.xhtml", "example/app/todo/spec/todo.rb", "example/app/todo/start.rb", "example/app/todo/view/index.xhtml", "example/app/whywiki_erb/layout/wiki.html.erb", "example/app/whywiki_erb/spec/wiki.rb", "example/app/whywiki_erb/start.rb", "example/app/whywiki_erb/view/edit.erb", "example/app/whywiki_erb/view/index.erb", "example/custom_middleware.rb", "example/hello.rb", "example/howto_spec.rb", "example/link.rb", "example/provides.rb", "example/session.rb", "innate.gemspec", "lib/innate.rb", "lib/innate/action.rb", "lib/innate/adapter.rb", "lib/innate/cache.rb", "lib/innate/cache/api.rb", "lib/innate/cache/drb.rb", "lib/innate/cache/file_based.rb", "lib/innate/cache/marshal.rb", "lib/innate/cache/memory.rb", "lib/innate/cache/yaml.rb", "lib/innate/current.rb", "lib/innate/default_middleware.rb", "lib/innate/dynamap.rb", "lib/innate/helper.rb", "lib/innate/helper/aspect.rb", "lib/innate/helper/cgi.rb", "lib/innate/helper/flash.rb", "lib/innate/helper/link.rb", "lib/innate/helper/redirect.rb", "lib/innate/helper/render.rb", "lib/innate/log.rb", "lib/innate/log/color_formatter.rb", "lib/innate/log/hub.rb", "lib/innate/lru_hash.rb", "lib/innate/mock.rb", "lib/innate/node.rb", "lib/innate/options.rb", "lib/innate/options/dsl.rb", "lib/innate/options/stub.rb", "lib/innate/request.rb", "lib/innate/response.rb", "lib/innate/route.rb", "lib/innate/session.rb", "lib/innate/session/flash.rb", "lib/innate/spec.rb", "lib/innate/spec/bacon.rb", "lib/innate/state.rb", "lib/innate/state/accessor.rb", "lib/innate/traited.rb", "lib/innate/trinity.rb", "lib/innate/version.rb", "lib/innate/view.rb", "lib/innate/view/erb.rb", "lib/innate/view/etanni.rb", "lib/innate/view/none.rb", "spec/example/app/retro_games.rb", "spec/example/hello.rb", "spec/example/link.rb", "spec/example/provides.rb", "spec/example/session.rb", "spec/helper.rb", "spec/innate/action/layout.rb", "spec/innate/action/layout/file_layout.xhtml", "spec/innate/cache/common.rb", "spec/innate/cache/marshal.rb", "spec/innate/cache/memory.rb", "spec/innate/cache/yaml.rb", "spec/innate/dynamap.rb", "spec/innate/etanni.rb", "spec/innate/helper.rb", "spec/innate/helper/aspect.rb", "spec/innate/helper/cgi.rb", "spec/innate/helper/flash.rb", "spec/innate/helper/link.rb", "spec/innate/helper/redirect.rb", "spec/innate/helper/render.rb", "spec/innate/helper/view/aspect_hello.xhtml", "spec/innate/helper/view/locals.xhtml", "spec/innate/helper/view/loop.xhtml", "spec/innate/helper/view/num.xhtml", "spec/innate/helper/view/partial.xhtml", "spec/innate/helper/view/recursive.xhtml", "spec/innate/mock.rb", "spec/innate/modes.rb", "spec/innate/node/mapping.rb", "spec/innate/node/node.rb", "spec/innate/node/resolve.rb", "spec/innate/node/view/another_layout/another_layout.xhtml", "spec/innate/node/view/bar.xhtml", "spec/innate/node/view/cat2/cat22.xhtml", "spec/innate/node/view/cat3/cat33.xhtml", "spec/innate/node/view/foo.html.xhtml", "spec/innate/node/view/only_view.xhtml", "spec/innate/node/view/sub/baz.xhtml", "spec/innate/node/view/sub/foo/baz.xhtml", "spec/innate/node/view/with_layout.xhtml", "spec/innate/node/wrap_action_call.rb", "spec/innate/options.rb", "spec/innate/parameter.rb", "spec/innate/provides.rb", "spec/innate/provides/list.html.xhtml", "spec/innate/provides/list.txt.xhtml", "spec/innate/request.rb", "spec/innate/response.rb", "spec/innate/route.rb", "spec/innate/session.rb", "spec/innate/traited.rb", "tasks/authors.rake", "tasks/bacon.rake", "tasks/changelog.rake", "tasks/gem.rake", "tasks/gem_setup.rake", "tasks/grancher.rake", "tasks/manifest.rake", "tasks/rcov.rake", "tasks/release.rake", "tasks/reversion.rake", "tasks/setup.rake", "tasks/ycov.rake"]
@@ -20,17 +20,21 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rack>, ["~> 1.6.4"])
+      s.add_runtime_dependency(%q<rack>, ["~> 3.0"])
       s.add_development_dependency(%q<bacon>, ["~> 1.2.0"])
-      s.add_development_dependency(%q<rack-test>, ["~> 0.6.3"])
+      s.add_development_dependency(%q<rack-test>, ["~> 2.0"])
+      s.add_development_dependency(%q<rackup>, ["~> 0.2"])
+      
     else
-      s.add_dependency(%q<rack>, ["~> 1.6.4"])
+      s.add_dependency(%q<rack>, ["~> 3.0"])
       s.add_dependency(%q<bacon>, ["~> 1.2.0"])
-      s.add_dependency(%q<rack-test>, ["~> 0.6.3"])
+      s.add_dependency(%q<rack-test>, ["~> 2.0"])
+      s.add_dependency(%q<rackup>, ["~> 0.2"])
     end
   else
-    s.add_dependency(%q<rack>, ["~> 1.6.4"])
+    s.add_dependency(%q<rack>, ["~> 3.0"])
     s.add_dependency(%q<bacon>, ["~> 1.2.0"])
-    s.add_dependency(%q<rack-test>, ["~> 0.6.3"])
+    s.add_dependency(%q<rack-test>, ["~> 2.0"])
+    s.add_dependency(%q<rackup>, ["~> 0.2"])
   end
 end

--- a/lib/innate.rb
+++ b/lib/innate.rb
@@ -213,7 +213,7 @@ module Innate
       roots, publics = options[:roots], options[:publics]
 
       joined  = roots.map { |root| publics.map { |p| File.join(root, p) } }
-      joined  = joined.flatten.map { |p| Rack::File.new(p) }
+      joined  = joined.flatten.map { |p| Rack::Files.new(p) }
       current = Current.new(Route.new(DynaMap), Rewrite.new(DynaMap))
 
       return Rack::Cascade.new(joined << current, [404, 405])

--- a/lib/innate/helper/redirect.rb
+++ b/lib/innate/helper/redirect.rb
@@ -57,7 +57,7 @@ module Innate
       end
 
       def raw_redirect(target, options = {}, &block)
-        header = response.header.merge('Location' => target.to_s)
+        header = response.headers.merge('Location' => target.to_s)
         status = options[:status] || 302
         body   = options[:body] || redirect_body(target)
 

--- a/lib/innate/request.rb
+++ b/lib/innate/request.rb
@@ -135,7 +135,7 @@ module Innate
       addr = IPAddr.new(address)
       LOCAL.find{|range| range.include?(addr) }
     rescue ArgumentError => ex
-      raise ArgumentError, ex unless ex.message == 'invalid address'
+      raise ArgumentError, ex unless ex.message =~ /invalid address/
     end
   end
 end

--- a/lib/innate/response.rb
+++ b/lib/innate/response.rb
@@ -13,7 +13,7 @@ module Innate
 
     def reset
       self.status = 200
-      self.header.delete('Content-Type')
+      self.headers.delete('Content-Type')
       body.clear
       self.length = 0
       self

--- a/lib/innate/route.rb
+++ b/lib/innate/route.rb
@@ -5,7 +5,7 @@ module Innate
   #
   # This middleware should wrap Innate::DynaMap.
   #
-  # Please note that Rack::File is put before Route and Rewrite, that means
+  # Please note that Rack::Files is put before Route and Rewrite, that means
   # that you cannot apply routes to static files unless you add your own route
   # middleware before.
   #

--- a/spec/innate/modes.rb
+++ b/spec/innate/modes.rb
@@ -16,12 +16,11 @@ describe 'Innate modes' do
   describe 'dev' do
     behaves_like :rack_test
     Innate.options.mode = :dev
-
     should 'handle GET request' do
       get('/').status.
         should == 200
       last_response.headers.
-        should == {'Content-Length' => '13', 'Content-Type' => 'text/html'}
+        should == {'content-length' => '13', 'content-type' => 'text/html'}
       last_response.body.
         should == 'Hello, World!'
     end
@@ -30,7 +29,7 @@ describe 'Innate modes' do
       head('/').status.
         should == 200
       last_response.headers.
-        should == {'Content-Length' => '13', 'Content-Type' => 'text/html'}
+        should == {'content-length' => '13', 'content-type' => 'text/html'}
       last_response.body.
         should == ''
     end
@@ -44,7 +43,7 @@ describe 'Innate modes' do
       get('/').status.
         should == 200
       last_response.headers.
-        should == {'Content-Length' => '13', 'Content-Type' => 'text/html'}
+        should == {'content-length' => '13', 'content-type' => 'text/html'}
       last_response.body.
         should == 'Hello, World!'
     end
@@ -53,7 +52,7 @@ describe 'Innate modes' do
       head('/').status.
         should == 200
       last_response.headers.
-        should == {'Content-Length' => '13', 'Content-Type' => 'text/html'}
+        should == {'content-length' => '13', 'content-type' => 'text/html'}
       last_response.body.
         should == ''
     end


### PR DESCRIPTION
The dependency on a now archaic version of rack has been a real thorn.  This fork includes a bare minimum of changes in order to get Innate working with the current version of rack.  All bacon tests are passing.